### PR TITLE
解决demo工程发送消息后account服务消费端监听无法接收到消息的问题

### DIFF
--- a/mykit-message-core/src/main/java/io/mykit/transaction/message/core/service/mq/receive/MykitMqReceiveServiceImpl.java
+++ b/mykit-message-core/src/main/java/io/mykit/transaction/message/core/service/mq/receive/MykitMqReceiveServiceImpl.java
@@ -198,7 +198,7 @@ public class MykitMqReceiveServiceImpl implements MykitMqReceiveService {
     }
 
     /**
-     * 由于通过反射执行业务方法时，业务会抛出RuntimeException
+     * 获取异常的详情
      * @param e
      * @return
      */

--- a/mykit-message-core/src/main/java/io/mykit/transaction/message/core/service/mq/receive/MykitMqReceiveServiceImpl.java
+++ b/mykit-message-core/src/main/java/io/mykit/transaction/message/core/service/mq/receive/MykitMqReceiveServiceImpl.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Objects;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -105,7 +106,7 @@ public class MykitMqReceiveServiceImpl implements MykitMqReceiveService {
                     publisher.publishEvent(log, EventTypeEnum.SAVE.getCode());
                 } catch (Exception e) {
                     //执行失败保存失败的日志
-                    final MykitTransaction log = buildTransactionLog(transId, e.getMessage(),
+                    final MykitTransaction log = buildTransactionLog(transId, getExceptionMessage(e),
                             MykitTransactionMessageStatusEnum.FAILURE.getCode(),
                             entity.getMykitTransactionMessageInvocation().getTargetClass().getName(),
                             entity.getMykitTransactionMessageInvocation().getMethodName());
@@ -132,7 +133,7 @@ public class MykitMqReceiveServiceImpl implements MykitMqReceiveService {
 
                     } catch (Throwable e) {
                         //执行失败，设置失败原因和重试次数
-                        mythTransaction.setErrorMsg(e.getMessage());
+                        mythTransaction.setErrorMsg(getExceptionMessage(e));
                         mythTransaction.setRetriedCount(mythTransaction.getRetriedCount() + 1);
                         publisher.publishEvent(mythTransaction, EventTypeEnum.UPDATE_FAIR.getCode());
                         throw new MykitRuntimeException(e);
@@ -194,5 +195,18 @@ public class MykitMqReceiveServiceImpl implements MykitMqReceiveService {
             }
         }
         return serializer;
+    }
+
+    /**
+     * 由于通过反射执行业务方法时，业务会抛出RuntimeException
+     * @param e
+     * @return
+     */
+    private String getExceptionMessage(Throwable e) {
+        String exceptionMessage = e.getMessage();
+        if (exceptionMessage == null && e instanceof InvocationTargetException && e.getCause() != null) {
+            exceptionMessage = e.getCause().getMessage();
+        }
+        return exceptionMessage;
     }
 }

--- a/mykit-message-demo/mykit-demo-dubbo/mykit-demo-dubbo-account-api/src/main/java/io/mykit/transaction/message/demo/dubbo/account/api/service/AccountService.java
+++ b/mykit-message-demo/mykit-demo-dubbo/mykit-demo-dubbo-account-api/src/main/java/io/mykit/transaction/message/demo/dubbo/account/api/service/AccountService.java
@@ -33,7 +33,7 @@ public interface AccountService {
      * @param accountDto 参数dto
      * @return true
      */
-    @MykitTransactionMessage(destination = "ORDER_FLOW_BQ",tags = "account")
+    @MykitTransactionMessage(destination = "account")
     boolean payment(AccountDto accountDto);
 
 


### PR DESCRIPTION
详情如下：
AmqpConfig.java中队列的名称是固定account，但在MykitInvokerInvocationHandler的buildParticipant时会看调用方法的注解上是否存在MykitTransactionMessage注解以及读取tags和destination得到最终的destination值

`if (mykitTransactionMessage.tags().length() > 0) {
      destination = mykitTransactionMessage.destination() + "," + mykitTransactionMessage.tags();
  } else {
      destination = mykitTransactionMessage.destination();
  }`

   因为现在接口上指定了tags，从而导致发送到的消息消费端无法监听到